### PR TITLE
onion_messenger: place subscribe to custom message in a loop.

### DIFF
--- a/src/offers/lnd_requests.rs
+++ b/src/offers/lnd_requests.rs
@@ -266,10 +266,13 @@ pub(crate) async fn connect_to_peer(
         .await
         .map_err(OfferError::PeerConnectError)?;
 
+    println!("=========going to connect with the peer");
     let node = match node.node {
         Some(node) => node,
         None => return Err(OfferError::NodeAddressNotFound),
     };
+
+    println!("======after checking node {:?}", node);
 
     if node.addresses.is_empty() {
         return Err(OfferError::NodeAddressNotFound);

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -490,34 +490,21 @@ impl LndNode {
     pub async fn check_lnd_running(
         &mut self,
         mut interval: Interval,
-        node_id: PublicKey,
     ) -> Result<(), Box<dyn Error>> {
         if let Some(client) = self.client.clone() {
-            let node_info_req = tonic_lnd::lnrpc::NodeInfoRequest {
-                pub_key: node_id.to_string(),
-                include_channels: false,
-            };
+            let get_info_req = GetInfoRequest {};
             loop {
                 select!(
                     _ = interval.tick() => {
                         match client
                             .clone()
                             .lightning()
-                            .get_node_info(node_info_req.clone())
+                            .get_info(get_info_req.clone())
                             .await {
-                                Ok(node_info) => {
-                                    if let Some(node) = node_info.into_inner().node {
-                                        if !node.addresses.is_empty() {
-                                            return Ok(());
-                                        } else {
-                                            log::trace!("Node {} found but has no addresses yet", node_id);
-                                        }
-                                    } else {
-                                        log::trace!("Node {} found in response but node field is None", node_id);
-                                    }
+                                Ok(_) => {
+                                    return Ok(())
                                 },
                                 Err(_) => {
-                                    log::trace!("Node info not found yet for {}", node_id);
                                     continue
                                 }
                             }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -490,22 +490,34 @@ impl LndNode {
     pub async fn check_lnd_running(
         &mut self,
         mut interval: Interval,
+        node_id: PublicKey,
     ) -> Result<(), Box<dyn Error>> {
         if let Some(client) = self.client.clone() {
-            let get_info_req = GetInfoRequest {};
+            let node_info_req = tonic_lnd::lnrpc::NodeInfoRequest {
+                pub_key: node_id.to_string(),
+                include_channels: false,
+            };
             loop {
                 select!(
                     _ = interval.tick() => {
                         match client
                             .clone()
                             .lightning()
-                            .get_info(get_info_req.clone())
+                            .get_node_info(node_info_req.clone())
                             .await {
-                                Ok(a) => {
-                                    println!("info is {:?}", a);
-                                    return Ok(())
+                                Ok(node_info) => {
+                                    if let Some(node) = node_info.into_inner().node {
+                                        if !node.addresses.is_empty() {
+                                            return Ok(());
+                                        } else {
+                                            log::trace!("Node {} found but has no addresses yet", node_id);
+                                        }
+                                    } else {
+                                        log::trace!("Node {} found in response but node field is None", node_id);
+                                    }
                                 },
                                 Err(_) => {
+                                    log::trace!("Node info not found yet for {}", node_id);
                                     continue
                                 }
                             }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -501,7 +501,8 @@ impl LndNode {
                             .lightning()
                             .get_info(get_info_req.clone())
                             .await {
-                                Ok(_) => {
+                                Ok(a) => {
+                                    println!("info is {:?}", a);
                                     return Ok(())
                                 },
                                 Err(_) => {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -643,7 +643,7 @@ async fn check_pay_offer_with_reconnection(
 
     // Even though LND is up and running, the GRPC service may not. Therefore,
     // an additional time is added to wait for the GRPC service.
-    tokio::time::sleep(Duration::from_millis(100)).await;
+    tokio::time::sleep(Duration::from_millis(500)).await;
 
     // Send another pay_offer process using the same handler.
     // Because of the reconnections, the handler has to be able to connect

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -643,7 +643,7 @@ async fn check_pay_offer_with_reconnection(
 
     // Even though LND is up and running, the GRPC service may not. Therefore,
     // an additional time is added to wait for the GRPC service.
-    tokio::time::sleep(Duration::from_millis(500)).await;
+    tokio::time::sleep(Duration::from_millis(100)).await;
 
     // Send another pay_offer process using the same handler.
     // Because of the reconnections, the handler has to be able to connect

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -605,7 +605,7 @@ async fn test_check_lndk_pay_offer_with_reconnection() {
         val = messenger.run(lndk_cfg.clone(), Arc::clone(&handler)) => {
             panic!("lndk should not have completed first {:?}", val);
         },
-        _ = check_pay_offer_with_reconnection(handler, pay_cfg.clone(), lnd) => {
+        _ = check_pay_offer_with_reconnection(handler, pay_cfg.clone(), lnd, ldk2_pubkey) => {
             shutdown.trigger();
             ldk1.stop().await;
             ldk2.stop().await;
@@ -617,6 +617,7 @@ async fn check_pay_offer_with_reconnection(
     handler: Arc<OfferHandler>,
     pay_cfg: PayOfferParams,
     lnd: common::LndNode,
+    node_id: PublicKey
 ) {
     let lnd_arc = Arc::new(tokio::sync::Mutex::new(lnd));
     let lnd_clone = Arc::clone(&lnd_arc);
@@ -638,12 +639,9 @@ async fn check_pay_offer_with_reconnection(
 
     let interval = time::interval(Duration::from_millis(500));
 
-    // Wait until LND is available again
-    lnd.check_lnd_running(interval).await.unwrap();
-
     // Even though LND is up and running, the GRPC service may not. Therefore,
     // an additional time is added to wait for the GRPC service.
-    tokio::time::sleep(Duration::from_millis(5000)).await;
+    lnd.check_lnd_running(interval, node_id).await.unwrap();
 
     // Send another pay_offer process using the same handler.
     // Because of the reconnections, the handler has to be able to connect

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -643,7 +643,7 @@ async fn check_pay_offer_with_reconnection(
 
     // Even though LND is up and running, the GRPC service may not. Therefore,
     // an additional time is added to wait for the GRPC service.
-    tokio::time::sleep(Duration::from_millis(100)).await;
+    tokio::time::sleep(Duration::from_millis(5000)).await;
 
     // Send another pay_offer process using the same handler.
     // Because of the reconnections, the handler has to be able to connect

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -623,13 +623,14 @@ async fn check_pay_offer_with_reconnection(
 
     // Setup a task to kill LND after the pay_offer has already started.
     tokio::spawn(async move {
-        tokio::time::sleep(Duration::from_millis(210)).await;
+        tokio::time::sleep(Duration::from_millis(270)).await;
         let mut lnd = lnd_clone.lock().await;
         lnd.kill_lnd().await;
     });
 
     // Start a pay_offer process.
     let res1 = handler.pay_offer(pay_cfg.clone()).await;
+    println!("====res1 answer {:?}", res1);
     let mut lnd = lnd_arc.lock().await;
 
     // Restart LND node with the same previous arguments.
@@ -649,6 +650,7 @@ async fn check_pay_offer_with_reconnection(
     // again to the restart LND node, fetched the peers, and be able to handle
     // a second pay_offer
     let res2 = handler.pay_offer(pay_cfg.clone()).await;
+    println!("====res2 answer {:?}", res2);
 
     // We check that the first pay_offer fails because the LND has been kill.
     assert!(res1.is_err());

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -605,7 +605,7 @@ async fn test_check_lndk_pay_offer_with_reconnection() {
         val = messenger.run(lndk_cfg.clone(), Arc::clone(&handler)) => {
             panic!("lndk should not have completed first {:?}", val);
         },
-        _ = check_pay_offer_with_reconnection(handler, pay_cfg.clone(), lnd) => {
+        _ = check_pay_offer_with_reconnection(handler, pay_cfg.clone(), lnd, ldk2_pubkey) => {
             shutdown.trigger();
             ldk1.stop().await;
             ldk2.stop().await;
@@ -617,6 +617,7 @@ async fn check_pay_offer_with_reconnection(
     handler: Arc<OfferHandler>,
     pay_cfg: PayOfferParams,
     lnd: common::LndNode,
+    node_id: PublicKey
 ) {
     let lnd_arc = Arc::new(tokio::sync::Mutex::new(lnd));
     let lnd_clone = Arc::clone(&lnd_arc);
@@ -638,13 +639,7 @@ async fn check_pay_offer_with_reconnection(
     let interval = time::interval(Duration::from_millis(500));
 
     // Wait until LND is available again
-    lnd.check_lnd_running(interval).await.unwrap();
-
-    // Even though LND is up and running, the GRPC service may not. Therefore,
-    // an additional time is added to wait for the GRPC service.
-    // Running the test in the CI, this time has to be even bigger because of the
-    // CI machine resources.
-    tokio::time::sleep(Duration::from_millis(5000)).await;
+    lnd.check_lnd_running(interval, node_id).await.unwrap();
 
     // Send another pay_offer process using the same handler.
     // Because of the reconnections, the handler has to be able to connect


### PR DESCRIPTION
When the connection with LND is broken, the subscription to custom message stream is also broken. Therefore, when the reconnection is done, it would not be possible to receive custom messages anymore. Placing the subscription to custom messages into a loop we can guarantee that after the reconnection to LND, the subscription to the custom message can be reestablish.